### PR TITLE
[fix] Dependency issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,6 @@
   },
   "dependencies": {
     "babel-runtime": "6.18.0",
-    "bcrypt": "^1.0.1",
-    "meteor-node-stubs": "~0.2.0",
     "vue": "^2.1.8",
     "vuex": "^2.1.1",
     "vue-meteor-tracker": "^1.0.4"


### PR DESCRIPTION
- We don't seem to actually use bcrypt
- These days, you don't want or need to explicitly depend on `meteor-node-stubs`
